### PR TITLE
Fix ONNX providers with SAM

### DIFF
--- a/labelme/ai/models/segment_anything.py
+++ b/labelme/ai/models/segment_anything.py
@@ -16,8 +16,8 @@ class SegmentAnythingModel:
 
         self._image_size = 1024
 
-        self._encoder_session = onnxruntime.InferenceSession(encoder_path)
-        self._decoder_session = onnxruntime.InferenceSession(decoder_path)
+        self._encoder_session = onnxruntime.InferenceSession(encoder_path, providers=['AzureExecutionProvider', 'CPUExecutionProvider'])
+        self._decoder_session = onnxruntime.InferenceSession(decoder_path, providers=['AzureExecutionProvider', 'CPUExecutionProvider'])
 
         self._lock = threading.Lock()
         self._image_embedding_cache = collections.OrderedDict()


### PR DESCRIPTION
Fixes #1334

The latest version of `onnxruntime.InferenceSession` seems to require `providers` are specified. This is a small patch that adds them in. I'm not sure if the values I specified were correct or optimal, but it allows SAM to work on my machine rather than crash. 