### PR TITLE
NEW FEATURE: Quick edit multiple labels at once

### DIFF
--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -113,5 +113,6 @@ shortcuts:
   undo_last_point: Ctrl+Z
   add_point_to_edge: Ctrl+Shift+P
   edit_label: Ctrl+E
+  multi_edit_labels: Ctrl+M
   toggle_keep_prev_mode: Ctrl+P
   remove_selected_point: [Meta+H, Backspace]


### PR DESCRIPTION
Sometimes, it becomes necessary to modify a pre-labeled dataset. In such cases, multi-edit functionality can enhance efficiency. Therefore, I have incorporated this feature.
![demo](https://github.com/wkentaro/labelme/assets/68468076/d9b7fd11-098f-42a7-bd93-42fbb68933d1)
