### PR TITLE
Introduce ruff to replace black, flake8 and isort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,17 +61,12 @@ jobs:
       run: |
         pip install .
 
-    - name: Lint with flake8
+    - name: Run ruff
       shell: bash -l {0}
       if: matrix.os != 'windows-latest'
       run: |
-        flake8 labelme/
-
-    - name: Black
-      shell: bash -l {0}
-      if: matrix.os != 'windows-latest'
-      run: |
-        black --line-length 79 --check --diff labelme/
+        ruff format --check
+        ruff check
 
     - name: Test with pytest
       shell: bash -l {0}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+all:
+	@echo '## Make commands ##'
+	@echo
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
+
+lint:
+	ruff format --check
+	ruff check
+
+format:
+	ruff format
+	ruff check --fix
+
+test:
+	MPLBACKEND='agg' pytest tests

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ See `.github/workflows/ci.yml` for more detail.
 ```bash
 pip install -r requirements-dev.txt
 
-flake8 .
-black --line-length 79 --check labelme/
+ruff format --check  # `ruff format` to auto-fix
+ruff check  # `ruff check --fix` to auto-fix
 MPLBACKEND='agg' pytest -vsx tests/
 ```
 

--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -9,6 +9,7 @@ import os.path as osp
 import sys
 
 import imgviz
+
 import labelme
 
 try:

--- a/examples/bbox_detection/labelme2voc.py
+++ b/examples/bbox_detection/labelme2voc.py
@@ -26,9 +26,7 @@ def main():
     parser.add_argument("input_dir", help="input annotated directory")
     parser.add_argument("output_dir", help="output dataset directory")
     parser.add_argument("--labels", help="labels file", required=True)
-    parser.add_argument(
-        "--noviz", help="no visualization", action="store_true"
-    )
+    parser.add_argument("--noviz", help="no visualization", action="store_true")
     args = parser.parse_args()
 
     if osp.exists(args.output_dir):
@@ -96,8 +94,9 @@ def main():
         for shape in label_file.shapes:
             if shape["shape_type"] != "rectangle":
                 print(
-                    "Skipping shape: label={label}, "
-                    "shape_type={shape_type}".format(**shape)
+                    "Skipping shape: label={label}, " "shape_type={shape_type}".format(
+                        **shape
+                    )
                 )
                 continue
 

--- a/examples/instance_segmentation/labelme2coco.py
+++ b/examples/instance_segmentation/labelme2coco.py
@@ -29,9 +29,7 @@ def main():
     parser.add_argument("input_dir", help="input annotated directory")
     parser.add_argument("output_dir", help="output dataset directory")
     parser.add_argument("--labels", help="labels file", required=True)
-    parser.add_argument(
-        "--noviz", help="no visualization", action="store_true"
-    )
+    parser.add_argument("--noviz", help="no visualization", action="store_true")
     args = parser.parse_args()
 
     if osp.exists(args.output_dir):
@@ -120,9 +118,7 @@ def main():
             label = shape["label"]
             group_id = shape.get("group_id")
             shape_type = shape.get("shape_type", "polygon")
-            mask = labelme.utils.shape_to_mask(
-                img.shape[:2], points, shape_type
-            )
+            mask = labelme.utils.shape_to_mask(img.shape[:2], points, shape_type)
 
             if group_id is None:
                 group_id = uuid.uuid1()
@@ -196,9 +192,7 @@ def main():
                     font_size=15,
                     line_width=2,
                 )
-            out_viz_file = osp.join(
-                args.output_dir, "Visualization", base + ".jpg"
-            )
+            out_viz_file = osp.join(args.output_dir, "Visualization", base + ".jpg")
             imgviz.io.imsave(out_viz_file, viz)
 
     with open(out_ann_file, "w") as f:

--- a/examples/tutorial/load_label_png.py
+++ b/examples/tutorial/load_label_png.py
@@ -7,7 +7,6 @@ import os.path as osp
 import numpy as np
 import PIL.Image
 
-
 here = osp.dirname(osp.abspath(__file__))
 
 

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -19,12 +19,8 @@ from labelme.utils import newIcon
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--version", "-V", action="store_true", help="show version"
-    )
-    parser.add_argument(
-        "--reset-config", action="store_true", help="reset qt config"
-    )
+    parser.add_argument("--version", "-V", action="store_true", help="show version")
+    parser.add_argument("--reset-config", action="store_true", help="reset qt config")
     parser.add_argument(
         "--logger-level",
         default="debug",

--- a/labelme/__main__.py
+++ b/labelme/__main__.py
@@ -4,8 +4,8 @@ import logging
 import os
 import os.path as osp
 import sys
-import yaml
 
+import yaml
 from qtpy import QtCore
 from qtpy import QtWidgets
 

--- a/labelme/ai/_utils.py
+++ b/labelme/ai/_utils.py
@@ -23,14 +23,10 @@ def compute_polygon_from_mask(mask):
     if 0:
         import PIL.Image
 
-        image_pil = PIL.Image.fromarray(
-            imgviz.gray2rgb(imgviz.bool2ubyte(mask))
-        )
+        image_pil = PIL.Image.fromarray(imgviz.gray2rgb(imgviz.bool2ubyte(mask)))
         imgviz.draw.line_(image_pil, yx=polygon, fill=(0, 255, 0))
         for point in polygon:
-            imgviz.draw.circle_(
-                image_pil, center=point, diameter=10, fill=(0, 255, 0)
-            )
+            imgviz.draw.circle_(image_pil, center=point, diameter=10, fill=(0, 255, 0))
         imgviz.io.imsave("contour.jpg", np.asarray(image_pil))
 
     return polygon[:, ::-1]  # yx -> xy

--- a/labelme/ai/efficient_sam.py
+++ b/labelme/ai/efficient_sam.py
@@ -38,18 +38,14 @@ class EfficientSam:
         with self._lock:
             logger.debug("Computing image embedding...")
             image = imgviz.rgba2rgb(self._image)
-            batched_images = (
-                image.transpose(2, 0, 1)[None].astype(np.float32) / 255.0
-            )
+            batched_images = image.transpose(2, 0, 1)[None].astype(np.float32) / 255.0
             (self._image_embedding,) = self._encoder_session.run(
                 output_names=None,
                 input_feed={"batched_images": batched_images},
             )
             if len(self._image_embedding_cache) > 10:
                 self._image_embedding_cache.popitem(last=False)
-            self._image_embedding_cache[
-                self._image.tobytes()
-            ] = self._image_embedding
+            self._image_embedding_cache[self._image.tobytes()] = self._image_embedding
             logger.debug("Done computing image embedding.")
 
     def _get_image_embedding(self):
@@ -69,9 +65,7 @@ class EfficientSam:
         )
 
     def predict_polygon_from_points(self, points, point_labels):
-        mask = self.predict_mask_from_points(
-            points=points, point_labels=point_labels
-        )
+        mask = self.predict_mask_from_points(points=points, point_labels=point_labels)
         return _utils.compute_polygon_from_mask(mask=mask)
 
 
@@ -103,7 +97,5 @@ def _compute_mask_from_points(
     )
 
     if 0:
-        imgviz.io.imsave(
-            "mask.jpg", imgviz.label2rgb(mask, imgviz.rgb2gray(image))
-        )
+        imgviz.io.imsave("mask.jpg", imgviz.label2rgb(mask, imgviz.rgb2gray(image)))
     return mask

--- a/labelme/ai/efficient_sam.py
+++ b/labelme/ai/efficient_sam.py
@@ -7,7 +7,6 @@ import onnxruntime
 import skimage
 
 from ..logger import logger
-
 from . import _utils
 
 

--- a/labelme/ai/segment_anything_model.py
+++ b/labelme/ai/segment_anything_model.py
@@ -46,9 +46,7 @@ class SegmentAnythingModel:
             )
             if len(self._image_embedding_cache) > 10:
                 self._image_embedding_cache.popitem(last=False)
-            self._image_embedding_cache[
-                self._image.tobytes()
-            ] = self._image_embedding
+            self._image_embedding_cache[self._image.tobytes()] = self._image_embedding
             logger.debug("Done computing image embedding.")
 
     def _get_image_embedding(self):
@@ -69,9 +67,7 @@ class SegmentAnythingModel:
         )
 
     def predict_polygon_from_points(self, points, point_labels):
-        mask = self.predict_mask_from_points(
-            points=points, point_labels=point_labels
-        )
+        mask = self.predict_mask_from_points(points=points, point_labels=point_labels)
         return _utils.compute_polygon_from_mask(mask=mask)
 
 
@@ -133,9 +129,9 @@ def _compute_mask_from_points(
     onnx_coord = np.concatenate([input_point, np.array([[0.0, 0.0]])], axis=0)[
         None, :, :
     ]
-    onnx_label = np.concatenate([input_label, np.array([-1])], axis=0)[
-        None, :
-    ].astype(np.float32)
+    onnx_label = np.concatenate([input_label, np.array([-1])], axis=0)[None, :].astype(
+        np.float32
+    )
 
     scale, new_height, new_width = _compute_scale_to_resize_image(
         image_size=image_size, image=image
@@ -167,7 +163,5 @@ def _compute_mask_from_points(
     )
 
     if 0:
-        imgviz.io.imsave(
-            "mask.jpg", imgviz.label2rgb(mask, imgviz.rgb2gray(image))
-        )
+        imgviz.io.imsave("mask.jpg", imgviz.label2rgb(mask, imgviz.rgb2gray(image)))
     return mask

--- a/labelme/ai/segment_anything_model.py
+++ b/labelme/ai/segment_anything_model.py
@@ -7,7 +7,6 @@ import onnxruntime
 import skimage
 
 from ..logger import logger
-
 from . import _utils
 
 

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -46,7 +46,6 @@ LABEL_COLORMAP = imgviz.label_colormap()
 
 
 class MainWindow(QtWidgets.QMainWindow):
-
     FIT_WINDOW, FIT_WIDTH, MANUAL_ZOOM = 0, 1, 2
 
     def __init__(
@@ -58,9 +57,7 @@ class MainWindow(QtWidgets.QMainWindow):
         output_dir=None,
     ):
         if output is not None:
-            logger.warning(
-                "argument output is deprecated, use output_file instead"
-            )
+            logger.warning("argument output is deprecated, use output_file instead")
             if output_file is None:
                 output_file = output
 
@@ -125,17 +122,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self.labelList.itemDoubleClicked.connect(self.editLabel)
         self.labelList.itemChanged.connect(self.labelItemChanged)
         self.labelList.itemDropped.connect(self.labelOrderChanged)
-        self.shape_dock = QtWidgets.QDockWidget(
-            self.tr("Polygon Labels"), self
-        )
+        self.shape_dock = QtWidgets.QDockWidget(self.tr("Polygon Labels"), self)
         self.shape_dock.setObjectName("Labels")
         self.shape_dock.setWidget(self.labelList)
 
         self.uniqLabelList = UniqueLabelQListWidget()
         self.uniqLabelList.setToolTip(
             self.tr(
-                "Select label to start annotating for it. "
-                "Press 'Esc' to deselect."
+                "Select label to start annotating for it. " "Press 'Esc' to deselect."
             )
         )
         if self._config["labels"]:
@@ -152,9 +146,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.fileSearch.setPlaceholderText(self.tr("Search Filename"))
         self.fileSearch.textChanged.connect(self.fileSearchChanged)
         self.fileListWidget = QtWidgets.QListWidget()
-        self.fileListWidget.itemSelectionChanged.connect(
-            self.fileSelectionChanged
-        )
+        self.fileListWidget.itemSelectionChanged.connect(self.fileSelectionChanged)
         fileListLayout = QtWidgets.QVBoxLayout()
         fileListLayout.setContentsMargins(0, 0, 0, 0)
         fileListLayout.setSpacing(0)
@@ -611,9 +603,7 @@ class MainWindow(QtWidgets.QMainWindow):
         labelMenu = QtWidgets.QMenu()
         utils.addActions(labelMenu, (edit, delete))
         self.labelList.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.labelList.customContextMenuRequested.connect(
-            self.popLabelListMenu
-        )
+        self.labelList.customContextMenuRequested.connect(self.popLabelListMenu)
 
         # Store actions for further handling.
         self.actions = utils.struct(
@@ -782,9 +772,7 @@ class MainWindow(QtWidgets.QMainWindow):
         selectAiModel.defaultWidget().layout().addWidget(selectAiModelLabel)
         #
         self._selectAiModelComboBox = QtWidgets.QComboBox()
-        selectAiModel.defaultWidget().layout().addWidget(
-            self._selectAiModelComboBox
-        )
+        selectAiModel.defaultWidget().layout().addWidget(self._selectAiModelComboBox)
         model_names = [model.name for model in MODELS]
         self._selectAiModelComboBox.addItems(model_names)
         if self._config["ai"]["default"] in model_names:
@@ -1302,9 +1290,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     description=s.description,
                     shape_type=s.shape_type,
                     flags=s.flags,
-                    mask=None
-                    if s.mask is None
-                    else utils.img_arr_to_b64(s.mask),
+                    mask=None if s.mask is None else utils.img_arr_to_b64(s.mask),
                 )
             )
             return data
@@ -1332,9 +1318,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 flags=flags,
             )
             self.labelFile = lf
-            items = self.fileListWidget.findItems(
-                self.imagePath, Qt.MatchExactly
-            )
+            items = self.fileListWidget.findItems(self.imagePath, Qt.MatchExactly)
             if len(items) > 0:
                 if len(items) != 1:
                     raise RuntimeError("There are duplicate files.")
@@ -1490,9 +1474,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actions.keepPrevScale.setChecked(enabled)
 
     def onNewBrightnessContrast(self, qimage):
-        self.canvas.loadPixmap(
-            QtGui.QPixmap.fromImage(qimage), clear_shapes=False
-        )
+        self.canvas.loadPixmap(QtGui.QPixmap.fromImage(qimage), clear_shapes=False)
 
     def brightnessContrast(self, value):
         dialog = BrightnessContrastDialog(
@@ -1539,16 +1521,12 @@ class MainWindow(QtWidgets.QMainWindow):
             )
             return False
         # assumes same name, but json extension
-        self.status(
-            str(self.tr("Loading %s...")) % osp.basename(str(filename))
-        )
+        self.status(str(self.tr("Loading %s...")) % osp.basename(str(filename)))
         label_file = osp.splitext(filename)[0] + ".json"
         if self.output_dir:
             label_file_without_path = osp.basename(label_file)
             label_file = osp.join(self.output_dir, label_file_without_path)
-        if QtCore.QFile.exists(label_file) and LabelFile.is_label_file(
-            label_file
-        ):
+        if QtCore.QFile.exists(label_file) and LabelFile.is_label_file(label_file):
             try:
                 self.labelFile = LabelFile(label_file)
             except LabelFileError as e:
@@ -1695,9 +1673,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def closeEvent(self, event):
         if not self.mayContinue():
             event.ignore()
-        self.settings.setValue(
-            "filename", self.filename if self.filename else ""
-        )
+        self.settings.setValue("filename", self.filename if self.filename else "")
         self.settings.setValue("window/size", self.size())
         self.settings.setValue("window/position", self.pos())
         self.settings.setValue("window/state", self.saveState())
@@ -1839,9 +1815,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if current_filename in self.imageList:
             # retain currently selected file
-            self.fileListWidget.setCurrentRow(
-                self.imageList.index(current_filename)
-            )
+            self.fileListWidget.setCurrentRow(self.imageList.index(current_filename))
             self.fileListWidget.repaint()
 
     def saveFile(self, _value=False):
@@ -1863,13 +1837,9 @@ class MainWindow(QtWidgets.QMainWindow):
         caption = self.tr("%s - Choose File") % __appname__
         filters = self.tr("Label files (*%s)") % LabelFile.suffix
         if self.output_dir:
-            dlg = QtWidgets.QFileDialog(
-                self, caption, self.output_dir, filters
-            )
+            dlg = QtWidgets.QFileDialog(self, caption, self.output_dir, filters)
         else:
-            dlg = QtWidgets.QFileDialog(
-                self, caption, self.currentPath(), filters
-            )
+            dlg = QtWidgets.QFileDialog(self, caption, self.currentPath(), filters)
         dlg.setDefaultSuffix(LabelFile.suffix[1:])
         dlg.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
         dlg.setOption(QtWidgets.QFileDialog.DontConfirmOverwrite, False)
@@ -1918,8 +1888,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def deleteFile(self):
         mb = QtWidgets.QMessageBox
         msg = self.tr(
-            "You are about to permanently delete this label file, "
-            "proceed anyway?"
+            "You are about to permanently delete this label file, " "proceed anyway?"
         )
         answer = mb.warning(self, self.tr("Attention"), msg, mb.Yes | mb.No)
         if answer != mb.Yes:
@@ -1956,9 +1925,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if not self.dirty:
             return True
         mb = QtWidgets.QMessageBox
-        msg = self.tr('Save annotations to "{}" before closing?').format(
-            self.filename
-        )
+        msg = self.tr('Save annotations to "{}" before closing?').format(self.filename)
         answer = mb.question(
             self,
             self.tr("Save annotations?"),
@@ -1999,8 +1966,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def deleteSelectedShape(self):
         yes, no = QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No
         msg = self.tr(
-            "You are about to permanently delete {} polygons, "
-            "proceed anyway?"
+            "You are about to permanently delete {} polygons, " "proceed anyway?"
         ).format(len(self.canvas.selectedShapes))
         if yes == QtWidgets.QMessageBox.warning(
             self, self.tr("Attention"), msg, yes | no, yes
@@ -2030,9 +1996,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.lastOpenDir and osp.exists(self.lastOpenDir):
             defaultOpenDirPath = self.lastOpenDir
         else:
-            defaultOpenDirPath = (
-                osp.dirname(self.filename) if self.filename else "."
-            )
+            defaultOpenDirPath = osp.dirname(self.filename) if self.filename else "."
 
         targetDirPath = str(
             QtWidgets.QFileDialog.getExistingDirectory(
@@ -2061,9 +2025,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.filename = None
         for file in imageFiles:
-            if file in self.imageList or not file.lower().endswith(
-                tuple(extensions)
-            ):
+            if file in self.imageList or not file.lower().endswith(tuple(extensions)):
                 continue
             label_file = osp.splitext(file)[0] + ".json"
             if self.output_dir:
@@ -2071,9 +2033,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 label_file = osp.join(self.output_dir, label_file_without_path)
             item = QtWidgets.QListWidgetItem(file)
             item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
-            if QtCore.QFile.exists(label_file) and LabelFile.is_label_file(
-                label_file
-            ):
+            if QtCore.QFile.exists(label_file) and LabelFile.is_label_file(label_file):
                 item.setCheckState(Qt.Checked)
             else:
                 item.setCheckState(Qt.Unchecked)
@@ -2104,9 +2064,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 label_file = osp.join(self.output_dir, label_file_without_path)
             item = QtWidgets.QListWidgetItem(filename)
             item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
-            if QtCore.QFile.exists(label_file) and LabelFile.is_label_file(
-                label_file
-            ):
+            if QtCore.QFile.exists(label_file) and LabelFile.is_label_file(label_file):
                 item.setCheckState(Qt.Checked)
             else:
                 item.setCheckState(Qt.Unchecked)

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -11,14 +11,12 @@ import webbrowser
 import imgviz
 import natsort
 from qtpy import QtCore
-from qtpy.QtCore import Qt
 from qtpy import QtGui
 from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
-from labelme import __appname__
 from labelme import PY2
-
-from . import utils
+from labelme import __appname__
 from labelme.ai import MODELS
 from labelme.config import get_config
 from labelme.label_file import LabelFile
@@ -34,6 +32,8 @@ from labelme.widgets import LabelListWidgetItem
 from labelme.widgets import ToolBar
 from labelme.widgets import UniqueLabelQListWidget
 from labelme.widgets import ZoomWidget
+
+from . import utils
 
 # FIXME
 # - [medium] Set max zoom value to something big enough for FitWidth/Window

--- a/labelme/cli/draw_json.py
+++ b/labelme/cli/draw_json.py
@@ -6,9 +6,8 @@ import sys
 import imgviz
 import matplotlib.pyplot as plt
 
-from labelme.label_file import LabelFile
 from labelme import utils
-
+from labelme.label_file import LabelFile
 
 PY2 = sys.version_info[0] == 2
 

--- a/labelme/cli/draw_json.py
+++ b/labelme/cli/draw_json.py
@@ -29,9 +29,7 @@ def main():
         else:
             label_value = len(label_name_to_value)
             label_name_to_value[label_name] = label_value
-    lbl, _ = utils.shapes_to_label(
-        img.shape, label_file.shapes, label_name_to_value
-    )
+    lbl, _ = utils.shapes_to_label(img.shape, label_file.shapes, label_name_to_value)
 
     label_names = [None] * (max(label_name_to_value.values()) + 1)
     for name, value in label_name_to_value.items():

--- a/labelme/cli/export_json.py
+++ b/labelme/cli/export_json.py
@@ -7,8 +7,8 @@ import os.path as osp
 import imgviz
 import PIL.Image
 
-from labelme.logger import logger
 from labelme import utils
+from labelme.logger import logger
 
 
 def main():

--- a/labelme/cli/export_json.py
+++ b/labelme/cli/export_json.py
@@ -45,9 +45,7 @@ def main():
         else:
             label_value = len(label_name_to_value)
             label_name_to_value[label_name] = label_value
-    lbl, _ = utils.shapes_to_label(
-        img.shape, data["shapes"], label_name_to_value
-    )
+    lbl, _ = utils.shapes_to_label(img.shape, data["shapes"], label_name_to_value)
 
     label_names = [None] * (max(label_name_to_value.values()) + 1)
     for name, value in label_name_to_value.items():

--- a/labelme/cli/json_to_dataset.py
+++ b/labelme/cli/json_to_dataset.py
@@ -55,9 +55,7 @@ def main():
         else:
             label_value = len(label_name_to_value)
             label_name_to_value[label_name] = label_value
-    lbl, _ = utils.shapes_to_label(
-        img.shape, data["shapes"], label_name_to_value
-    )
+    lbl, _ = utils.shapes_to_label(img.shape, data["shapes"], label_name_to_value)
 
     label_names = [None] * (max(label_name_to_value.values()) + 1)
     for name, value in label_name_to_value.items():

--- a/labelme/cli/json_to_dataset.py
+++ b/labelme/cli/json_to_dataset.py
@@ -7,8 +7,8 @@ import os.path as osp
 import imgviz
 import PIL.Image
 
-from labelme.logger import logger
 from labelme import utils
+from labelme.logger import logger
 
 
 def main():

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -44,9 +44,7 @@ def get_default_config():
 def validate_config_item(key, value):
     if key == "validate_label" and value not in [None, "exact"]:
         raise ValueError(
-            "Unexpected value for config key 'validate_label': {}".format(
-                value
-            )
+            "Unexpected value for config key 'validate_label': {}".format(value)
         )
     if key == "shape_color" and value not in [None, "auto", "manual"]:
         raise ValueError(
@@ -67,18 +65,12 @@ def get_config(config_file_or_yaml=None, config_from_args=None):
         config_from_yaml = yaml.safe_load(config_file_or_yaml)
         if not isinstance(config_from_yaml, dict):
             with open(config_from_yaml) as f:
-                logger.info(
-                    "Loading config file from: {}".format(config_from_yaml)
-                )
+                logger.info("Loading config file from: {}".format(config_from_yaml))
                 config_from_yaml = yaml.safe_load(f)
-        update_dict(
-            config, config_from_yaml, validate_item=validate_config_item
-        )
+        update_dict(config, config_from_yaml, validate_item=validate_config_item)
 
     # 3. command line argument or specified config file
     if config_from_args is not None:
-        update_dict(
-            config, config_from_args, validate_item=validate_config_item
-        )
+        update_dict(config, config_from_args, validate_item=validate_config_item)
 
     return config

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -5,7 +5,6 @@ import yaml
 
 from labelme.logger import logger
 
-
 here = osp.dirname(osp.abspath(__file__))
 
 

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -6,12 +6,11 @@ import os.path as osp
 
 import PIL.Image
 
-from labelme import __version__
-from labelme.logger import logger
 from labelme import PY2
 from labelme import QT4
+from labelme import __version__
 from labelme import utils
-
+from labelme.logger import logger
 
 PIL.Image.MAX_IMAGE_PIXELS = None
 

--- a/labelme/label_file.py
+++ b/labelme/label_file.py
@@ -33,7 +33,6 @@ class LabelFileError(Exception):
 
 
 class LabelFile(object):
-
     suffix = ".json"
 
     def __init__(self, filename=None):
@@ -113,12 +112,8 @@ class LabelFile(object):
                     flags=s.get("flags", {}),
                     description=s.get("description"),
                     group_id=s.get("group_id"),
-                    mask=utils.img_b64_to_arr(s["mask"])
-                    if s.get("mask")
-                    else None,
-                    other_data={
-                        k: v for k, v in s.items() if k not in shape_keys
-                    },
+                    mask=utils.img_b64_to_arr(s["mask"]) if s.get("mask") else None,
+                    other_data={k: v for k, v in s.items() if k not in shape_keys},
                 )
                 for s in data["shapes"]
             ]

--- a/labelme/logger.py
+++ b/labelme/logger.py
@@ -12,7 +12,6 @@ if os.name == "nt":  # Windows
 
 from . import __appname__
 
-
 COLORS = {
     "WARNING": "yellow",
     "INFO": "white",

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -2,13 +2,12 @@ import copy
 import math
 
 import numpy as np
+import skimage.measure
 from qtpy import QtCore
 from qtpy import QtGui
-import skimage.measure
 
-from labelme.logger import logger
 import labelme.utils
-
+from labelme.logger import logger
 
 # TODO(unknown):
 # - [opt] Store paths instead of creating new ones at each paint.

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -15,7 +15,6 @@ import labelme.utils
 
 
 class Shape(object):
-
     # Render handles as squares
     P_SQUARE = 0
 
@@ -194,9 +193,7 @@ class Shape(object):
                 else self.fill_color.getRgb()
             )
             image_to_draw[self.mask] = fill_color
-            qimage = QtGui.QImage.fromData(
-                labelme.utils.img_arr_to_data(image_to_draw)
-            )
+            qimage = QtGui.QImage.fromData(labelme.utils.img_arr_to_data(image_to_draw))
             painter.drawImage(
                 int(round(self.points[0].x())),
                 int(round(self.points[0].y())),
@@ -204,9 +201,7 @@ class Shape(object):
             )
 
             line_path = QtGui.QPainterPath()
-            contours = skimage.measure.find_contours(
-                np.pad(self.mask, pad_width=1)
-            )
+            contours = skimage.measure.find_contours(np.pad(self.mask, pad_width=1))
             for contour in contours:
                 contour += [self.points[0].y(), self.points[0].x()]
                 line_path.moveTo(contour[0, 1], contour[0, 0])
@@ -241,9 +236,7 @@ class Shape(object):
                     self.drawVertex(vrtx_path, i)
             elif self.shape_type == "points":
                 assert len(self.points) == len(self.point_labels)
-                for i, (p, l) in enumerate(
-                    zip(self.points, self.point_labels)
-                ):
+                for i, (p, l) in enumerate(zip(self.points, self.point_labels)):
                     if l == 1:
                         self.drawVertex(vrtx_path, i)
                     else:
@@ -266,11 +259,7 @@ class Shape(object):
                 painter.drawPath(vrtx_path)
                 painter.fillPath(vrtx_path, self._vertex_fill_color)
             if self.fill and self.mask is None:
-                color = (
-                    self.select_fill_color
-                    if self.selected
-                    else self.fill_color
-                )
+                color = self.select_fill_color if self.selected else self.fill_color
                 painter.fillPath(line_path, color)
 
             pen.setColor(QtGui.QColor(255, 0, 0, 255))

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -236,8 +236,8 @@ class Shape(object):
                     self.drawVertex(vrtx_path, i)
             elif self.shape_type == "points":
                 assert len(self.points) == len(self.point_labels)
-                for i, (p, l) in enumerate(zip(self.points, self.point_labels)):
-                    if l == 1:
+                for i, point_label in enumerate(self.point_labels):
+                    if point_label == 1:
                         self.drawVertex(vrtx_path, i)
                     else:
                         self.drawVertex(negative_vrtx_path, i)

--- a/labelme/testing.py
+++ b/labelme/testing.py
@@ -2,6 +2,7 @@ import json
 import os.path as osp
 
 import imgviz
+
 import labelme.utils
 
 

--- a/labelme/utils/image.py
+++ b/labelme/utils/image.py
@@ -72,11 +72,7 @@ def apply_exif_orientation(image):
     if exif is None:
         return image
 
-    exif = {
-        PIL.ExifTags.TAGS[k]: v
-        for k, v in exif.items()
-        if k in PIL.ExifTags.TAGS
-    }
+    exif = {PIL.ExifTags.TAGS[k]: v for k, v in exif.items() if k in PIL.ExifTags.TAGS}
 
     orientation = exif.get("Orientation", None)
 

--- a/labelme/utils/qt.py
+++ b/labelme/utils/qt.py
@@ -1,12 +1,10 @@
-from math import sqrt
 import os.path as osp
+from math import sqrt
 
 import numpy as np
-
 from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
-
 
 here = osp.dirname(osp.abspath(__file__))
 

--- a/labelme/utils/shape.py
+++ b/labelme/utils/shape.py
@@ -10,15 +10,12 @@ from labelme.logger import logger
 
 def polygons_to_mask(img_shape, polygons, shape_type=None):
     logger.warning(
-        "The 'polygons_to_mask' function is deprecated, "
-        "use 'shape_to_mask' instead."
+        "The 'polygons_to_mask' function is deprecated, " "use 'shape_to_mask' instead."
     )
     return shape_to_mask(img_shape, points=polygons, shape_type=shape_type)
 
 
-def shape_to_mask(
-    img_shape, points, shape_type=None, line_width=10, point_size=5
-):
+def shape_to_mask(img_shape, points, shape_type=None, line_width=10, point_size=5):
     mask = np.zeros(img_shape[:2], dtype=np.uint8)
     mask = PIL.Image.fromarray(mask)
     draw = PIL.ImageDraw.Draw(mask)
@@ -77,8 +74,7 @@ def shapes_to_label(img_shape, shapes, label_name_to_value):
 
 def labelme_shapes_to_label(img_shape, shapes):
     logger.warn(
-        "labelme_shapes_to_label is deprecated, so please use "
-        "shapes_to_label."
+        "labelme_shapes_to_label is deprecated, so please use " "shapes_to_label."
     )
 
     label_name_to_value = {"_background_": 0}
@@ -96,9 +92,7 @@ def labelme_shapes_to_label(img_shape, shapes):
 
 def masks_to_bboxes(masks):
     if masks.ndim != 3:
-        raise ValueError(
-            "masks.ndim must be 3, but it is {}".format(masks.ndim)
-        )
+        raise ValueError("masks.ndim must be 3, but it is {}".format(masks.ndim))
     if masks.dtype != bool:
         raise ValueError(
             "masks.dtype must be bool type, but it is {}".format(masks.dtype)

--- a/labelme/widgets/brightness_contrast_dialog.py
+++ b/labelme/widgets/brightness_contrast_dialog.py
@@ -1,8 +1,8 @@
 import PIL.Image
 import PIL.ImageEnhance
-from qtpy.QtCore import Qt
 from qtpy import QtGui
 from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 from .. import utils
 

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -4,11 +4,10 @@ from qtpy import QtGui
 from qtpy import QtWidgets
 
 import labelme.ai
-from labelme.logger import logger
-from labelme import QT5
-from labelme.shape import Shape
 import labelme.utils
-
+from labelme import QT5
+from labelme.logger import logger
+from labelme.shape import Shape
 
 # TODO(unknown):
 # - [maybe] Find optimal epsilon value.

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -24,7 +24,6 @@ MOVE_SPEED = 5.0
 
 
 class Canvas(QtWidgets.QWidget):
-
     zoomRequest = QtCore.Signal(int, QtCore.QPoint)
     scrollRequest = QtCore.Signal(int, int)
     newShape = QtCore.Signal()
@@ -45,9 +44,7 @@ class Canvas(QtWidgets.QWidget):
         self.double_click = kwargs.pop("double_click", "close")
         if self.double_click not in [None, "close"]:
             raise ValueError(
-                "Unexpected value for double_click event: {}".format(
-                    self.double_click
-                )
+                "Unexpected value for double_click event: {}".format(self.double_click)
             )
         self.num_backups = kwargs.pop("num_backups", 10)
         self._crosshair = kwargs.pop(
@@ -307,9 +304,7 @@ class Canvas(QtWidgets.QWidget):
                 self.boundedMoveShapes(self.selectedShapesCopy, pos)
                 self.repaint()
             elif self.selectedShapes:
-                self.selectedShapesCopy = [
-                    s.copy() for s in self.selectedShapes
-                ]
+                self.selectedShapesCopy = [s.copy() for s in self.selectedShapes]
                 self.repaint()
             return
 
@@ -436,9 +431,7 @@ class Canvas(QtWidgets.QWidget):
                             label=self.line.point_labels[1],
                         )
                         self.line.points[0] = self.current.points[-1]
-                        self.line.point_labels[0] = self.current.point_labels[
-                            -1
-                        ]
+                        self.line.point_labels[0] = self.current.point_labels[-1]
                         if ev.modifiers() & QtCore.Qt.ControlModifier:
                             self.finalise()
                 elif not self.outOfPixmap(pos):
@@ -448,9 +441,7 @@ class Canvas(QtWidgets.QWidget):
                         if self.createMode in ["ai_polygon", "ai_mask"]
                         else self.createMode
                     )
-                    self.current.addPoint(
-                        pos, label=0 if is_shift_pressed else 1
-                    )
+                    self.current.addPoint(pos, label=0 if is_shift_pressed else 1)
                     if self.createMode == "point":
                         self.finalise()
                     elif (
@@ -489,8 +480,7 @@ class Canvas(QtWidgets.QWidget):
         elif ev.button() == QtCore.Qt.RightButton and self.editing():
             group_mode = int(ev.modifiers()) == QtCore.Qt.ControlModifier
             if not self.selectedShapes or (
-                self.hShape is not None
-                and self.hShape not in self.selectedShapes
+                self.hShape is not None and self.hShape not in self.selectedShapes
             ):
                 self.selectShapePoint(pos, multiple_selection_mode=group_mode)
                 self.repaint()
@@ -500,10 +490,7 @@ class Canvas(QtWidgets.QWidget):
         if ev.button() == QtCore.Qt.RightButton:
             menu = self.menus[len(self.selectedShapesCopy) > 0]
             self.restoreCursor()
-            if (
-                not menu.exec_(self.mapToGlobal(ev.pos()))
-                and self.selectedShapesCopy
-            ):
+            if not menu.exec_(self.mapToGlobal(ev.pos())) and self.selectedShapesCopy:
                 # Cancel the move by deleting the shadow copy.
                 self.selectedShapesCopy = []
                 self.repaint()
@@ -520,10 +507,7 @@ class Canvas(QtWidgets.QWidget):
 
         if self.movingShape and self.hShape:
             index = self.shapes.index(self.hShape)
-            if (
-                self.shapesBackups[-1][index].points
-                != self.shapes[index].points
-            ):
+            if self.shapesBackups[-1][index].points != self.shapes[index].points:
                 self.storeShapes()
                 self.shapeMoved.emit()
 
@@ -584,9 +568,7 @@ class Canvas(QtWidgets.QWidget):
                     self.setHiding()
                     if shape not in self.selectedShapes:
                         if multiple_selection_mode:
-                            self.selectionChanged.emit(
-                                self.selectedShapes + [shape]
-                            )
+                            self.selectionChanged.emit(self.selectedShapes + [shape])
                         else:
                             self.selectionChanged.emit([shape])
                         self.hShapeIsSelected = False
@@ -731,9 +713,7 @@ class Canvas(QtWidgets.QWidget):
 
         Shape.scale = self.scale
         for shape in self.shapes:
-            if (shape.selected or not self._hideBackround) and self.isVisible(
-                shape
-            ):
+            if (shape.selected or not self._hideBackround) and self.isVisible(shape):
                 shape.fill = shape.selected or shape == self.hShape
                 shape.paint(p)
         if self.current:
@@ -767,17 +747,13 @@ class Canvas(QtWidgets.QWidget):
                 label=self.line.point_labels[1],
             )
             points = self._ai_model.predict_polygon_from_points(
-                points=[
-                    [point.x(), point.y()] for point in drawing_shape.points
-                ],
+                points=[[point.x(), point.y()] for point in drawing_shape.points],
                 point_labels=drawing_shape.point_labels,
             )
             if len(points) > 2:
                 drawing_shape.setShapeRefined(
                     shape_type="polygon",
-                    points=[
-                        QtCore.QPointF(point[0], point[1]) for point in points
-                    ],
+                    points=[QtCore.QPointF(point[0], point[1]) for point in points],
                     point_labels=[1] * len(points),
                 )
                 drawing_shape.fill = self.fillDrawing()
@@ -790,14 +766,10 @@ class Canvas(QtWidgets.QWidget):
                 label=self.line.point_labels[1],
             )
             mask = self._ai_model.predict_mask_from_points(
-                points=[
-                    [point.x(), point.y()] for point in drawing_shape.points
-                ],
+                points=[[point.x(), point.y()] for point in drawing_shape.points],
                 point_labels=drawing_shape.point_labels,
             )
-            y1, x1, y2, x2 = imgviz.instances.mask_to_bbox([mask])[0].astype(
-                int
-            )
+            y1, x1, y2, x2 = imgviz.instances.mask_to_bbox([mask])[0].astype(int)
             drawing_shape.setShapeRefined(
                 shape_type="mask",
                 points=[QtCore.QPointF(x1, y1), QtCore.QPointF(x2, y2)],
@@ -832,15 +804,11 @@ class Canvas(QtWidgets.QWidget):
             # convert points to polygon by an AI model
             assert self.current.shape_type == "points"
             points = self._ai_model.predict_polygon_from_points(
-                points=[
-                    [point.x(), point.y()] for point in self.current.points
-                ],
+                points=[[point.x(), point.y()] for point in self.current.points],
                 point_labels=self.current.point_labels,
             )
             self.current.setShapeRefined(
-                points=[
-                    QtCore.QPointF(point[0], point[1]) for point in points
-                ],
+                points=[QtCore.QPointF(point[0], point[1]) for point in points],
                 point_labels=[1] * len(points),
                 shape_type="polygon",
             )
@@ -848,14 +816,10 @@ class Canvas(QtWidgets.QWidget):
             # convert points to mask by an AI model
             assert self.current.shape_type == "points"
             mask = self._ai_model.predict_mask_from_points(
-                points=[
-                    [point.x(), point.y()] for point in self.current.points
-                ],
+                points=[[point.x(), point.y()] for point in self.current.points],
                 point_labels=self.current.point_labels,
             )
-            y1, x1, y2, x2 = imgviz.instances.mask_to_bbox([mask])[0].astype(
-                int
-            )
+            y1, x1, y2, x2 = imgviz.instances.mask_to_bbox([mask])[0].astype(int)
             self.current.setShapeRefined(
                 shape_type="mask",
                 points=[QtCore.QPointF(x1, y1), QtCore.QPointF(x2, y2)],
@@ -974,9 +938,7 @@ class Canvas(QtWidgets.QWidget):
 
     def moveByKeyboard(self, offset):
         if self.selectedShapes:
-            self.boundedMoveShapes(
-                self.selectedShapes, self.prevPoint + offset
-            )
+            self.boundedMoveShapes(self.selectedShapes, self.prevPoint + offset)
             self.repaint()
             self.movingShape = True
 
@@ -1010,10 +972,7 @@ class Canvas(QtWidgets.QWidget):
         elif self.editing():
             if self.movingShape and self.selectedShapes:
                 index = self.shapes.index(self.selectedShapes[0])
-                if (
-                    self.shapesBackups[-1][index].points
-                    != self.shapes[index].points
-                ):
+                if self.shapesBackups[-1][index].points != self.shapes[index].points:
                     self.storeShapes()
                     self.shapeMoved.emit()
 

--- a/labelme/widgets/escapable_qlist_widget.py
+++ b/labelme/widgets/escapable_qlist_widget.py
@@ -1,5 +1,5 @@
-from qtpy.QtCore import Qt
 from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 
 class EscapableQListWidget(QtWidgets.QListWidget):

--- a/labelme/widgets/file_dialog_preview.py
+++ b/labelme/widgets/file_dialog_preview.py
@@ -52,9 +52,7 @@ class FileDialogPreview(QtWidgets.QFileDialog):
         if path.lower().endswith(".json"):
             with open(path, "r") as f:
                 data = json.load(f)
-                self.labelPreview.setText(
-                    json.dumps(data, indent=4, sort_keys=False)
-                )
+                self.labelPreview.setText(json.dumps(data, indent=4, sort_keys=False))
             self.labelPreview.label.setAlignment(
                 QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop
             )

--- a/labelme/widgets/file_dialog_preview.py
+++ b/labelme/widgets/file_dialog_preview.py
@@ -1,8 +1,8 @@
+import json
+
 from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
-
-import json
 
 
 class ScrollAreaPreview(QtWidgets.QScrollArea):

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -5,9 +5,8 @@ from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
 
-from labelme.logger import logger
 import labelme.utils
-
+from labelme.logger import logger
 
 QT5 = QT_VERSION[0] == "5"
 

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -75,22 +75,16 @@ class LabelDialog(QtWidgets.QDialog):
         # label_list
         self.labelList = QtWidgets.QListWidget()
         if self._fit_to_content["row"]:
-            self.labelList.setHorizontalScrollBarPolicy(
-                QtCore.Qt.ScrollBarAlwaysOff
-            )
+            self.labelList.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         if self._fit_to_content["column"]:
-            self.labelList.setVerticalScrollBarPolicy(
-                QtCore.Qt.ScrollBarAlwaysOff
-            )
+            self.labelList.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self._sort_labels = sort_labels
         if labels:
             self.labelList.addItems(labels)
         if self._sort_labels:
             self.labelList.sortItems()
         else:
-            self.labelList.setDragDropMode(
-                QtWidgets.QAbstractItemView.InternalMove
-            )
+            self.labelList.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
         self.labelList.currentItemChanged.connect(self.labelSelected)
         self.labelList.itemDoubleClicked.connect(self.labelDoubleClicked)
         self.labelList.setFixedHeight(150)
@@ -206,17 +200,13 @@ class LabelDialog(QtWidgets.QDialog):
             return int(group_id)
         return None
 
-    def popUp(
-        self, text=None, move=True, flags=None, group_id=None, description=None
-    ):
+    def popUp(self, text=None, move=True, flags=None, group_id=None, description=None):
         if self._fit_to_content["row"]:
             self.labelList.setMinimumHeight(
                 self.labelList.sizeHintForRow(0) * self.labelList.count() + 2
             )
         if self._fit_to_content["column"]:
-            self.labelList.setMinimumWidth(
-                self.labelList.sizeHintForColumn(0) + 2
-            )
+            self.labelList.setMinimumWidth(self.labelList.sizeHintForColumn(0) + 2)
         # if text is None, the previous label in self.edit is kept
         if text is None:
             text = self.edit.text()

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -1,8 +1,8 @@
 from qtpy import QtCore
-from qtpy.QtCore import Qt
 from qtpy import QtGui
-from qtpy.QtGui import QPalette
 from qtpy import QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QPalette
 from qtpy.QtWidgets import QStyle
 
 

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -33,9 +33,7 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
         if option.state & QStyle.State_Selected:
             ctx.palette.setColor(
                 QPalette.Text,
-                option.palette.color(
-                    QPalette.Active, QPalette.HighlightedText
-                ),
+                option.palette.color(QPalette.Active, QPalette.HighlightedText),
             )
         else:
             ctx.palette.setColor(
@@ -95,7 +93,6 @@ class LabelListWidgetItem(QtGui.QStandardItem):
 
 
 class StandardItemModel(QtGui.QStandardItemModel):
-
     itemDropped = QtCore.Signal()
 
     def removeRows(self, *args, **kwargs):
@@ -105,7 +102,6 @@ class StandardItemModel(QtGui.QStandardItemModel):
 
 
 class LabelListWidget(QtWidgets.QListView):
-
     itemDoubleClicked = QtCore.Signal(LabelListWidgetItem)
     itemSelectionChanged = QtCore.Signal(list, list)
 
@@ -122,9 +118,7 @@ class LabelListWidget(QtWidgets.QListView):
         self.setDefaultDropAction(Qt.MoveAction)
 
         self.doubleClicked.connect(self.itemDoubleClickedEvent)
-        self.selectionModel().selectionChanged.connect(
-            self.itemSelectionChangedEvent
-        )
+        self.selectionModel().selectionChanged.connect(self.itemSelectionChangedEvent)
 
     def __len__(self):
         return self.model().rowCount()
@@ -146,9 +140,7 @@ class LabelListWidget(QtWidgets.QListView):
 
     def itemSelectionChangedEvent(self, selected, deselected):
         selected = [self.model().itemFromIndex(i) for i in selected.indexes()]
-        deselected = [
-            self.model().itemFromIndex(i) for i in deselected.indexes()
-        ]
+        deselected = [self.model().itemFromIndex(i) for i in deselected.indexes()]
         self.itemSelectionChanged.emit(selected, deselected)
 
     def itemDoubleClickedEvent(self, index):

--- a/labelme/widgets/tool_bar.py
+++ b/labelme/widgets/tool_bar.py
@@ -22,7 +22,5 @@ class ToolBar(QtWidgets.QToolBar):
 
         # center align
         for i in range(self.layout().count()):
-            if isinstance(
-                self.layout().itemAt(i).widget(), QtWidgets.QToolButton
-            ):
+            if isinstance(self.layout().itemAt(i).widget(), QtWidgets.QToolButton):
                 self.layout().itemAt(i).setAlignment(QtCore.Qt.AlignCenter)

--- a/labelme/widgets/unique_label_qlist_widget.py
+++ b/labelme/widgets/unique_label_qlist_widget.py
@@ -22,9 +22,7 @@ class UniqueLabelQListWidget(EscapableQListWidget):
 
     def createItemFromLabel(self, label):
         if self.findItemByLabel(label):
-            raise ValueError(
-                "Item for label '{}' already exists".format(label)
-            )
+            raise ValueError("Item for label '{}' already exists".format(label))
 
         item = QtWidgets.QListWidgetItem()
         item.setData(Qt.UserRole, label)

--- a/labelme/widgets/unique_label_qlist_widget.py
+++ b/labelme/widgets/unique_label_qlist_widget.py
@@ -2,8 +2,8 @@
 
 import html
 
-from qtpy.QtCore import Qt
 from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 from .escapable_qlist_widget import EscapableQListWidget
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
-black==22.8.0
 github2pypi==1.0.0
-hacking==4.1.0
 pytest
 pytest-qt
+ruff
 twine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 github2pypi==1.0.0
 pytest
 pytest-qt
-ruff
+ruff==0.1.9
 twine

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,10 +8,8 @@ line-length = 88
 indent-width = 4
 
 [lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
-# McCabe complexity (`C901`) by default.
-select = ["E", "I"]
+# Enable Pyflakes (`F`), pycodestyle (`E`), isort (`I`).
+select = ["E", "F", "I"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/ruff.toml
+++ b/ruff.toml
@@ -11,7 +11,7 @@ indent-width = 4
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E"]
+select = ["E", "I"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -30,3 +30,6 @@ skip-magic-trailing-comma = false
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
+
+[isort]
+force-single-line = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,7 +4,7 @@ exclude = [
   "src",
 ]
 
-line-length = 79
+line-length = 88
 indent-width = 4
 
 [lint]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,32 @@
+exclude = [
+  ".conda",
+  ".git",
+  "src",
+]
+
+line-length = 79
+indent-width = 4
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,7 @@ from setuptools import setup
 def get_version():
     filename = "labelme/__init__.py"
     with open(filename) as f:
-        match = re.search(
-            r"""^__version__ = ['"]([^'"]*)['"]""", f.read(), re.M
-        )
+        match = re.search(r"""^__version__ = ['"]([^'"]*)['"]""", f.read(), re.M)
     if not match:
         raise RuntimeError("{} doesn't contain __version__".format(filename))
     version = match.groups()[0]

--- a/tests/labelme_tests/test_app.py
+++ b/tests/labelme_tests/test_app.py
@@ -8,7 +8,6 @@ import labelme.app
 import labelme.config
 import labelme.testing
 
-
 here = osp.dirname(osp.abspath(__file__))
 data_dir = osp.join(here, "data")
 

--- a/tests/labelme_tests/test_app.py
+++ b/tests/labelme_tests/test_app.py
@@ -83,7 +83,9 @@ def test_MainWindow_annotate_jpg(qtbot):
 
     config = labelme.config.get_default_config()
     win = labelme.app.MainWindow(
-        config=config, filename=input_file, output_file=out_file,
+        config=config,
+        filename=input_file,
+        output_file=out_file,
     )
     qtbot.addWidget(win)
     _win_show_and_wait_imageData(qtbot, win)

--- a/tests/labelme_tests/utils_tests/test_shape.py
+++ b/tests/labelme_tests/utils_tests/test_shape.py
@@ -1,6 +1,6 @@
-from .util import get_img_and_data
-
 from labelme.utils import shape as shape_module
+
+from .util import get_img_and_data
 
 
 def test_shapes_to_label():

--- a/tests/labelme_tests/utils_tests/util.py
+++ b/tests/labelme_tests/utils_tests/util.py
@@ -4,7 +4,6 @@ import os.path as osp
 from labelme.utils import image as image_module
 from labelme.utils import shape as shape_module
 
-
 here = osp.dirname(osp.abspath(__file__))
 data_dir = osp.join(here, "../data")
 

--- a/tests/labelme_tests/widgets_tests/test_label_dialog.py
+++ b/tests/labelme_tests/widgets_tests/test_label_dialog.py
@@ -54,9 +54,7 @@ def test_LabelDialog_popUp(qtbot):
     # popUp(text='cat')
 
     def interact():
-        qtbot.keyClick(
-            widget.edit, QtCore.Qt.Key_P
-        )  # enter 'p' for 'person'  # NOQA
+        qtbot.keyClick(widget.edit, QtCore.Qt.Key_P)  # enter 'p' for 'person'  # NOQA
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_Enter)  # NOQA
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_Enter)  # NOQA
 
@@ -83,9 +81,7 @@ def test_LabelDialog_popUp(qtbot):
     # popUp() + key_Up
 
     def interact():
-        qtbot.keyClick(
-            widget.edit, QtCore.Qt.Key_Up
-        )  # 'person' -> 'dog'  # NOQA
+        qtbot.keyClick(widget.edit, QtCore.Qt.Key_Up)  # 'person' -> 'dog'  # NOQA
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_Enter)  # NOQA
         qtbot.keyClick(widget.edit, QtCore.Qt.Key_Enter)  # NOQA
 


### PR DESCRIPTION
## Why?

- Ruff is faster and single command
- Ruff supports configuration without pyproject.toml (couldn't use pyproject.toml to configure black since it won't work with pyinstaller for some reason.)