### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format code with black
+5c9808446a179176c721bd7a59d621b41c95898c


### PR DESCRIPTION
This PR adds a `.git-blame-ignore-revs` file (as e.g. [supported by GitHub](https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/)), initially containing a reference to the reformatting commit 5c9808446a179176c721bd7a59d621b41c95898c.

Could be expanded with more.